### PR TITLE
T1 convert calc to array

### DIFF
--- a/calc.py
+++ b/calc.py
@@ -1,4 +1,3 @@
-#import unittest
 import datetime
 
 def add_years(d, years):

--- a/calc.py
+++ b/calc.py
@@ -15,7 +15,9 @@ def calculate_redundancy(brth_dt, strt_dt, wk_py, rdndnt_dt = datetime.datetime(
     Creation date: 2020-08-20
     Purpose: given DOB, Start date with the company, weekly pay, and date of redundancy,
     return the statutory redundancy payout value (uncapped).
-    Show all your working so the reader can be confident the answer is correct."""
+    Show all your working so the reader can be confident the answer is correct.
+    
+    NB: wk_pay is an integer number of pennies, handled internally as tenths!"""
 
     tdy_dt = datetime.datetime.today() # Note: not used in the calculation; only used to supress printing of future dates.
     print('Born: {}'.format(brth_dt.strftime("%d %b %Y")))
@@ -42,7 +44,8 @@ def calculate_redundancy(brth_dt, strt_dt, wk_py, rdndnt_dt = datetime.datetime(
 
     print('Assuming your position becomes redundant on {}, the payout would be calculated as follows...'.format(rdndnt_dt.strftime("%d %b %Y")))
 
-    tot_ent = 0
+    tot_ent = 0 # return Value
+
     if strt2_dt > rdndnt_dt:
         print('You do not qualify for statutory redundancy until you have been employed for 2 years or longer.')
 
@@ -51,35 +54,40 @@ def calculate_redundancy(brth_dt, strt_dt, wk_py, rdndnt_dt = datetime.datetime(
         # One week's pay for each full year you were 22 or older and under 41, and
         # 1 1/2 week's pay for each full year you were 41 or older.
 
+        # First off, convert wk_py from an ingeger number of pennies, to tenths of a penny.
+        wk_py = int(wk_py * 10)
+
         curr_year = strt_dt
         curr_ent = 0
+        ent = (int(wk_py * 0.5), wk_py, int(wk_py * 1.5)) # should be a tuple of 3 ints
         for s in range (srvc):
 
             if curr_age < 21:
-                curr_ent = wk_py * 0.5
-            elif 21 < curr_age < 41:
-                curr_ent = wk_py
+                curr_ent = ent[0]
+            elif 21 <= curr_age < 41:
+                curr_ent = ent[1]
             elif 41 <= curr_age:
-                curr_ent = wk_py *1.5
+                curr_ent = ent[2]
             else:
                 print('ERROR! Please contact support! Error:{}'.format(curr_age))
 
-            print("Year: {:2d}, SOY date: {}, Age: {}, Entitlement: {:06.2f}".format(s+1, curr_year.strftime("%d %b %Y"), curr_age, curr_ent))
-            tot_ent += curr_ent
+            print("Year: {:2d}, SOY date: {}, Age: {}, Entitlement: {:06.2f}".format(s+1, curr_year.strftime("%d %b %Y"), curr_age, curr_ent/1000))
             curr_year = add_years(curr_year, 1)
+            tot_ent += curr_ent
             curr_age += 1
 
-    print('Sum total of all entitlement: £{:06.2f}'.format(tot_ent))
+    print('Sum total of all entitlement: £{:06.2f}'.format(tot_ent/1000))
     print(' ')
 
-    return tot_ent
+    return int(tot_ent/10) # Convert from tenths of a penny, back into pennies
 
 def main():
     print('Michael')
     brth_dt = datetime.datetime(1970, 3, 30)
     strt_dt = datetime.datetime(2018, 10, 14)
-    wk_py = 1058
+    wk_py = 101300
     calculate_redundancy(brth_dt, strt_dt, wk_py)
+
 
 if __name__=="__main__":
     main()

--- a/test.py
+++ b/test.py
@@ -17,15 +17,24 @@ class TestExMethods(unittest.TestCase):
         print('Michael')
         brth_dt = datetime.datetime(1970, 3, 30)
         strt_dt = datetime.datetime(2018, 10, 14)
-        wk_py = 1058
+        wk_py = 101300 # This is a completely made up number
         self.assertEqual( calc.calculate_redundancy(brth_dt, strt_dt, wk_py), 0)
 
-    def test_spyros(self):
-        print('Spyros')
+    def test_vincent(self):
+        print('Vincent')
         brth_dt = datetime.datetime(1972, 3, 30)
-        strt_dt = datetime.datetime(2011, 2, 27)
-        wk_py = 1169
-        self.assertEqual( calc.calculate_redundancy(brth_dt, strt_dt, wk_py), 14028.00)
+        strt_dt = datetime.datetime(2011, 3, 27)
+        wk_py = 120100
+        self.assertEqual( calc.calculate_redundancy(brth_dt, strt_dt, wk_py), 1501250)
+
+    def test_joe(self):
+        print('Joe Bloggs')
+        brth_dt = datetime.datetime(1989, 6, 30)
+        strt_dt = datetime.datetime(2010, 3, 27)
+        wk_py = 67307.69
+        print(calc.calculate_redundancy(brth_dt, strt_dt, wk_py))
+        print('!!!!!!!!!!!!!!!!!!!!!!!')
+        self.assertEqual( calc.calculate_redundancy(brth_dt, strt_dt, wk_py), 639422)
 
 
 if __name__=="__main__":


### PR DESCRIPTION
1. Improve efficiency using a tuple
2. Fix rounding bug by using an integer number of pennies for wk_pay instead of float pounds and pennies; use tenths of a penny in calculation to prevent float rounding errors.
3. Remove a redundant comment