### PR TITLE
Length of service is capped at 20 years​

### DIFF
--- a/calc.py
+++ b/calc.py
@@ -8,46 +8,21 @@ def add_years(d, years):
     except ValueError: # 29 Feb, 31 Sep etc.
         return d + (datetime.datetime.date(d.year + years, 1, 1) - datetime.datetime.date(d.year, 1, 1))
 
-
-def calculate_redundancy(brth_dt, strt_dt, wk_py, rdndnt_dt = datetime.datetime(2020, 9, 5)):
-    """Original author: MWS
-    Creation date: 2020-08-20
-    Purpose: given DOB, Start date with the company, weekly pay, and date of redundancy,
-    return the statutory redundancy payout value (uncapped).
-    Show all your working so the reader can be confident the answer is correct.
-    
-    NB: wk_pay is an integer number of pennies, handled internally as tenths!"""
-
-    tdy_dt = datetime.datetime.today() # Note: not used in the calculation; only used to suppress printing of future dates.
-    print('Born: {}'.format(brth_dt.strftime("%d %b %Y")))
-
-    brth21_dt = add_years(brth_dt, 21) # Note: this variable is not used anywhere else.
-    if brth21_dt < tdy_dt:
-        print('21 on: {}'.format(brth21_dt.strftime("%d %b %Y")))
-
-    brth41_dt = add_years(brth_dt, 41) # Note: this variable is not used anywhere else.
-    if brth41_dt < tdy_dt:
-        print('41 on: {}'.format(brth41_dt.strftime("%d %b %Y")))
-
-    print('Started on: {}'.format(strt_dt.strftime("%d %b %Y")))
-
-    curr_age = (strt_dt - brth_dt).days//365
-    print('Age at time of joining: {}'.format(curr_age))
-
-    strt2_dt = add_years(strt_dt, 2)
-    if strt2_dt < tdy_dt:
-        print('2nd work anniversary on: {}'.format(strt2_dt.strftime("%d %b %Y")))
-
-    srvc = (rdndnt_dt-strt_dt).days//365
-    print('You have {} complete years of service'.format(srvc))
-
-    print('Your average weekly pay is: £{}'.format(wk_py/100))
-
-    print('Assuming your position becomes redundant on {}, the payout would be calculated as follows...'.format(rdndnt_dt.strftime("%d %b %Y")))
-
-    tot_ent = 0 # return Value
-
-    if strt2_dt > rdndnt_dt:
+def calculate_redundancy(rdndnt_dt, curr_age, curr_yr, wk_py):
+    """
+    Original author: MWS
+    Creation date: 2020-00-11
+    Purpose: given 4 parameters,
+        What date were you made redundant?
+        How old were you on the date you were made redundant?
+        How many years have you worked for your employer? and
+        What is your weekly pay before tax and any other deductions?
+    """
+    print("Redundant on: {}".format(rdndnt_dt))
+    print("Current age: {}".format(curr_age))
+    print("Employed for {} years".format(curr_yr))
+    tot_ent : int = 0 # return Value
+    if curr_yr < 2:
         print('You do not qualify for statutory redundancy until you have been employed for 2 years or longer.')
 
     else:
@@ -56,39 +31,41 @@ def calculate_redundancy(brth_dt, strt_dt, wk_py, rdndnt_dt = datetime.datetime(
         # 1 1/2 week's pay for each full year you were 41 or older.
 
         # First off, convert wk_py from an integer number of pennies, to tenths of a penny.
-        wk_py = int(wk_py * 10)
+        wk_py : int = int(wk_py * 10)
 
-        curr_year = strt_dt
-        curr_ent = 0
-        ent = (int(wk_py * 0.5), wk_py, int(wk_py * 1.5)) # should be a tuple of 3 ints
-        for s in range (srvc):
-
+        # Calculate the three different rates
+        ent : tuple = (int(wk_py * 0.5), wk_py, int(wk_py * 1.5)) # should be a tuple of 3 ints
+        
+        # Calculate total entitlement, capped at 20 years
+        for y in range(min([20, curr_yr])):
             if curr_age < 21:
                 curr_ent = ent[0]
             elif 21 <= curr_age < 41:
                 curr_ent = ent[1]
-            elif 41 <= curr_age:
+            elif curr_age >= 41:
                 curr_ent = ent[2]
             else:
                 print('ERROR! Please contact support! Error:{}'.format(curr_age))
 
-            print("Year: {:2d}, SOY date: {}, Age: {}, Entitlement: {:06.2f}".format(s+1, curr_year.strftime("%d %b %Y"), curr_age, curr_ent/1000))
-            curr_year = add_years(curr_year, 1)
+            print("Year: {}, age:{}, amount: {:06.2f}".format(curr_yr-y, curr_age, curr_ent/1000))
             tot_ent += curr_ent
-            curr_age += 1
+            curr_age -= 1
 
+    # print the result
+    if 20 < curr_yr:
+        print("Capped at 20 years")
     print('Sum total of all entitlement: £{:06.2f}'.format(tot_ent/1000))
     print(' ')
 
-    return int(tot_ent/10) # Convert from tenths of a penny, back into pennies
+    # Convert back from tenths of a penny to pennies for the calling program
+    return int(tot_ent/10)
+
+    # =================================================================================================================
 
 def main():
     print('Joe Bloggs')
-    brth_dt = datetime.datetime(1989, 6, 30)
-    strt_dt = datetime.datetime(2010, 3, 27)
-    wk_py = 67307.69 # £637.0769 per week, in pennies.
-    calculate_redundancy(brth_dt, strt_dt, wk_py)
+    wk_py : float = 67307.69 # £637.0769 per week, in pennies.
+    calculate_redundancy(rdndnt_dt = datetime.datetime(2020, 9, 25), curr_age = 29, curr_yr = 10, wk_py = wk_py)
 
 if __name__=="__main__":
     main()
-#    unittest.main()

--- a/test.py
+++ b/test.py
@@ -4,7 +4,6 @@ import calc
 
 class TestExMethods(unittest.TestCase):
     """docstring for TestExMethods."""
-    rdndnt_dt = datetime.datetime(2020, 9, 5)
 
     def test_add_years(self):
         print('test_add_years')
@@ -15,26 +14,17 @@ class TestExMethods(unittest.TestCase):
 
     def test_michael(self):
         print('Michael')
-        brth_dt = datetime.datetime(1970, 3, 30)
-        strt_dt = datetime.datetime(2018, 10, 14)
-        wk_py = 101300 # This is a completely made up number
-        self.assertEqual( calc.calculate_redundancy(brth_dt, strt_dt, wk_py), 0)
+         # This is a completely made up number
+        self.assertEqual( calc.calculate_redundancy(rdndnt_dt = datetime.datetime(2020, 9, 25), curr_age = 50, curr_yr = 1, wk_py = 101300), 0)
 
     def test_vincent(self):
         print('Vincent')
-        brth_dt = datetime.datetime(1972, 3, 30)
-        strt_dt = datetime.datetime(2011, 3, 27)
-        wk_py = 120100
-        self.assertEqual( calc.calculate_redundancy(brth_dt, strt_dt, wk_py), 1501250)
+        self.assertEqual( calc.calculate_redundancy(rdndnt_dt = datetime.datetime(2020, 9, 25), curr_age = 49, curr_yr = 10, wk_py = 120100), 1741450)
 
     def test_joe(self):
         print('Joe Bloggs')
-        brth_dt = datetime.datetime(1989, 6, 30)
-        strt_dt = datetime.datetime(2010, 3, 27)
-        wk_py = 67307.69
-        print(calc.calculate_redundancy(brth_dt, strt_dt, wk_py))
         print('!!!!!!!!!!!!!!!!!!!!!!!')
-        self.assertEqual( calc.calculate_redundancy(brth_dt, strt_dt, wk_py), 639422)
+        self.assertEqual( calc.calculate_redundancy(rdndnt_dt = datetime.datetime(2020, 9, 25), curr_age = 29, curr_yr = 10, wk_py = 67307.69), 639422)
 
 
 if __name__=="__main__":


### PR DESCRIPTION
The algorithm is wrong. There are 2 ways of working out the answer and this one uses the wrong way. Instead of using your date of birth, working out your age at time of joining and working FORWARDS, it should use your age on leaving and work BACKWARDS.
Consider a person retiring at age 62 with 22 years service (joined age 40). Working forwards you have 1 year paid out at weekly pay rate, wk_py, plus 21 years at 1.5 times wk_py. Capped at a total of 20 years = x. Working backwards you have 21 years at 1.5 times wk_py, capped at 20 years = y. y>x.
Calc should be based on:

    What date were you made redundant?
    How old were you on the date you were made redundant?
    How many years have you worked for your employer? and
    What is your weekly pay before tax and any other deductions?
